### PR TITLE
feat: adapt server version 1.21.5+ text component

### DIFF
--- a/src/guguwebui/web_server.py
+++ b/src/guguwebui/web_server.py
@@ -3484,9 +3484,9 @@ async def send_chat_message(request: Request):
             player_uuid = "未知"
         
         # 构建tellraw命令
-		hover_event_key = "hoverEvent"
-		server_version = server.get_server_information().version
-		from packaging import version as version_tool
+        hover_event_key = "hoverEvent"
+        server_version = server.get_server_information().version
+        from packaging import version as version_tool
         server_version = version_tool.parse(server_version)
         tellraw_format_changed_from = version_tool.parse("1.21.5")
         if server_version >= tellraw_format_changed_from:


### PR DESCRIPTION
fix: #21 
适配1.21.5以上版本的文本组件（仅修改标签名，建议在MCDR v2.15以后使用官方的RText组件）